### PR TITLE
initialize lipstick hack from init

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -712,6 +712,12 @@ service xtwifi_inet /system/bin/xtwifi-inet-agent
     group inet gps
     disabled
 
+service lipstickhack /usr/bin/droid/lipstick-hack.sh
+    class core
+    user system
+    oneshot
+    group graphics drmrpc
+
 # Charger
 on charger
     # persist.sys.usb.config is defined in default.prop, override it


### PR DESCRIPTION
the hack broke in SFOS 3.3.0, initialize it from init

see: https://wiki.merproject.org/wiki/Adaptations/faq-hadk